### PR TITLE
Allow Technicolor to be used on maps that use Chroma, but don't define a color for items

### DIFF
--- a/Technicolor/HarmonyPatches/TechniBomb.cs
+++ b/Technicolor/HarmonyPatches/TechniBomb.cs
@@ -19,7 +19,7 @@ namespace Technicolor.HarmonyPatches
         [AffinityPatch(typeof(BombNoteController), nameof(BombNoteController.Init))]
         private void Colorize(BombNoteController __instance, NoteData noteData)
         {
-            _manager.Colorize(__instance, TechnicolorController.GetTechnicolor(
+            _manager.GlobalColorize(TechnicolorController.GetTechnicolor(
                 true,
                 noteData.time + __instance.GetInstanceID(),
                 _config.TechnicolorBombsStyle));

--- a/Technicolor/HarmonyPatches/TechniLights.cs
+++ b/Technicolor/HarmonyPatches/TechniLights.cs
@@ -35,7 +35,7 @@ namespace Technicolor.HarmonyPatches
                 foreach (ILightWithId light in lightColorizer.Lights)
                 {
                     Color color = TechnicolorController.GetTechnicolor(warm, beatmapEventData.time + light.GetHashCode(), _config.TechnicolorLightsStyle);
-                    lightColorizer.Colorize(false, color, color, color, color);
+                    lightColorizer.Colorize(true, color, color, color, color);
                     __instance.Refresh(true, new[] { light }, beatmapEventData);
                 }
 
@@ -53,11 +53,11 @@ namespace Technicolor.HarmonyPatches
                 switch (_config.TechnicolorLightsGrouping)
                 {
                     case TechnicolorLightsGrouping.ISOLATED_GROUP:
-                        lightColorizer.Colorize(false, color, color, color, color);
+                        lightColorizer.Colorize(true, color, color, color, color);
                         break;
 
                     default:
-                        _manager.GlobalColorize(false, color, color, color, color);
+                        _manager.GlobalColorize(true, color, color, color, color);
                         break;
                 }
             }

--- a/Technicolor/TechnicolorController.cs
+++ b/Technicolor/TechnicolorController.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel;
+using System.Reflection;
+using Heck.Module;
 using Technicolor.Managers;
 using UnityEngine;
 using Random = System.Random;


### PR DESCRIPTION
Reproduction steps:
1. Load a map that uses Chroma but not for walls, e.g. lights only

Expectation:
Technicolour should be on the walls unless the mapper has explicitly defined a wall colour for the specific wall.

Reality:
Walls use the standard defined colour palette. No Technicolour.